### PR TITLE
Clarify that vTCP is not going away any time soon

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
       <textarea data-template>
         ## What’s staying the same?
         GCN Classic is not going away any time soon. The following are still fully supported:
-        * GCN Notices legacy delivery mechanisms (email, socket)
+        * GCN Notices legacy delivery mechanisms (email, socket, VOEvent Transport Protocol)
         * GCN Circulars submission and delivery via email
         * The old GCN Classic web site, https://gcn.gsfc.nasa.gov
         * The live archives of [GCN Notices](https://gcn.gsfc.nasa.gov/burst_info.html) and [GCN Circulars](https://gcn.gsfc.nasa.gov/gcn3_archive.html) on the old web site


### PR DESCRIPTION
This was an important clarification at the ongoing Paris-Saclay symposium.