### PR TITLE
Replace 'Scott Barthelmey' with 'the GCN Team'

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,7 +495,7 @@
           <textarea data-template>
             ## Self-service email alerts
             Email is still the most popular way to receive GCN Notices.
-            * Previously, users had to contact Scott Barthelmy to create or modify their subscriptions manually.
+            * Previously, users had to contact the GCN Team to create or modify their subscriptions manually.
             * Now, you can manage your email subscriptions yourself through our new web site.
             * **Note**: to cancel legacy email subscriptions on the old web site, [contact us](https://heasarc.gsfc.nasa.gov/cgi-bin/Feedback?selected=gcnclassic).
           </textarea>


### PR DESCRIPTION
This text would not make sense to someone who was not already very familiar to GCN Classic.